### PR TITLE
Fix limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A version of the Harrow-Hassidim-Lloyd algorithm implemented in Silq.
 
 ## Limitations
 
-- Reverse of a function needs to be declared before it is called
 - Change in global state leaks across while loop, which makes it hard to interpret the quantum state. See this issue: https://github.com/eth-sri/silq/issues/29#issue-1015256570
 
 ## References

--- a/hhl.slq
+++ b/hhl.slq
@@ -6,15 +6,13 @@ import examples;
 // approx_λ - eigenvalues of A - assume fractions
 // orB - oracle that can prepare the vector b from an initial qubit state
 // hamU - implementation of hamiltonian operator hamU(ctrl, i, t, b)
-// revhamU - temporary implementation of reverse of hamU
 // M - measurement operator to be applied before measuring
 def hhl[n:!N, prec:!N](
     const t :!R,
     const approx_λ : !N^(2^n),
-    const orB : uint[n] -> mfree uint[n],
-    const hamU: const B × const !R × const !R × uint[n] ->mfree uint[n],
-    const revhamU: const B × const !R × const !R × uint[n] ->mfree uint[n],
-    const M : uint[n] -> mfree uint[n])
+    const orB : uint[n] !-> mfree uint[n],
+    const hamU: const B × const !R × const !R × uint[n] !->mfree uint[n],
+    const M : uint[n] !-> mfree uint[n])
 {
  
     repeat_loop := true:!B;
@@ -39,7 +37,7 @@ def hhl[n:!N, prec:!N](
 
         // Inverse QPE
         eigen_qs := qft[prec](eigen_qs);
-        b_q := qpe_ham_loop[n, prec](eigen_qs, t, revhamU, b_q);
+        b_q := qpe_ham_loop[n, prec](eigen_qs, t, reverse(hamU), b_q);
         eigen_qs := H_n[prec](eigen_qs);
         
         // Measure ancillary
@@ -85,7 +83,7 @@ def main(){
     results := vector(2, 0:!N);
     for i in [0..1){
         print(i);
-        res := hhl[n, prec](t, approx_λ, orB2x2C[n], hamU2x2C[n], reverse(hamU2x2C[n]), m2X2C[n]);
+        res := hhl[n, prec](t, approx_λ, orB2x2C[n], hamU2x2C[n], m2X2C[n]);
         results[res] += 1;
     }
     print(results);

--- a/utils.slq
+++ b/utils.slq
@@ -47,7 +47,7 @@ def qft[n:!ℕ](ψ: uint[n])mfree: uint[n]{
 def qpe_ham_loop[n:!N, prec:!N](
     const ctrl:uint[prec],
     const t:!R,
-    const hamU: const B × const !R × const !R × uint[n] ->mfree uint[n],
+    const hamU: const B × const !R × const !R × uint[n] !->mfree uint[n],
     q:uint[n])
     mfree
 {


### PR DESCRIPTION
`reverse` expects a function without quantum captures, because the consumption of quantum captures by the function does not have an obvious reverse. (They would need to be produced, but it's unclear where to put them.)

```
f: a ->mfree b // quantum f potentially captures a quantum state
g: a !->mfree b // classical g can not capture a quantum state

reverse(f); // illegal
reverse(g): // works
```

I assume that the fact that `hhl` takes functions that potentially close over quantum variables was unintentional, caused by bad documentation on our side. Therefore, I marked all of those functions classical.

The syntax `a !-> b` means the same as `!(a -> b)`.